### PR TITLE
recipes: gnuradio: remove ICE as a dependency

### DIFF
--- a/recipes/gnuradio.lwr
+++ b/recipes/gnuradio.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-depends: make boost fftw cppunit swig gsl uhd alsa git python cheetah wxpython numpy lxml pygtk pycairo cmake pyqt4 pyqwt5 gcc ice
+depends: make boost fftw cppunit swig gsl uhd alsa git python cheetah wxpython numpy lxml pygtk pycairo cmake pyqt4 pyqwt5 gcc
 category: common
 satisfy_deb: gnuradio-dev
 source: git://http://www.gnuradio.org/git/gnuradio.git


### PR DESCRIPTION
We don't require it and it causes installs of other dependencies not needed.