### PR TITLE
recipes: mcpp: changed download location to use sourceforge

### DIFF
--- a/recipes/mcpp.lwr
+++ b/recipes/mcpp.lwr
@@ -21,7 +21,8 @@ depends: curl wget
 category: baseline
 satisfy_deb: (libmcpp-dev >= 2.7.2) && (mcpp >= 2.7.2)
 satisfy_rpm: mcpp-devel >= 2.7.2
-source: file://dist/mcpp_2.7.2.orig.tar.gz, wget://http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz
+#source: file://dist/mcpp_2.7.2.orig.tar.gz, wget://http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz
+source: file://dist/mcpp_2.7.2.orig.tar.gz, wget://http://prdownloads.sourceforge.net/mcpp/mcpp-2.7.2.tar.gz
 #source: file://dist/mcpp_2.7.2.orig.tar.gz
 #source: wget://http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz
 


### PR DESCRIPTION
The current recipe points to a URL that no longer seems to be responding. This patch updates to use sourceforge, which I think should be more stable.